### PR TITLE
Removed misplaced word main

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@ var offset = 300, // browser window scroll (in pixels) after which the "back to 
                     </div>
                 </div>
             </div>
- main
+
 
             </div>
             <div class="col">


### PR DESCRIPTION
Removed 'main' word in between 2nd & 3rd blog posts on Home page.

Fixes issue #170 

**Hacktoberfest 2022**

Thank you!